### PR TITLE
Add fix for action parameters issue

### DIFF
--- a/obs_plugin/src/obs_plugin.cpp
+++ b/obs_plugin/src/obs_plugin.cpp
@@ -1598,7 +1598,7 @@ bool logi::applets::obs_plugin::helper_populate_collections()
         bfree(scene_collections);
     }
 
-    auto current_collection = m_obs_collections[current_collection_name];
+    auto &current_collection = m_obs_collections[current_collection_name];
 
     current_collection.clear();
 
@@ -1622,7 +1622,7 @@ bool logi::applets::obs_plugin::helper_populate_collections()
         }
 
         auto *obs_scenes = new scene_info;
-        auto current_collection_scene = current_collection[name_str];
+        auto &current_collection_scene = current_collection[name_str];
 
         current_collection_scene.sources.clear();
 


### PR DESCRIPTION
**Issue** : Action parameters are not visible in the frontend drop down menu for OBS integration.
**Root Cause** : While fetching collections from obs plugin, we are accessing the `m_obs_collections` as a copy and modifying them which is a temporary change leading to the issue.
**Solution Implemented** : While accessing `m_obs_collections`, changing the copy to reference by adding **reference operator** `(&)`  did the job.
