### PR TITLE
Feature/fusion 1417 remove boost asio

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "other/json"]
 	path = other/json
 	url = https://github.com/nlohmann/json
-[submodule "other/websocketpp"]
-	path = other/websocketpp
-	url = https://github.com/zaphoyd/websocketpp
 [submodule "other/asio"]
 	path = other/asio
 	url = https://github.com/chriskohlhoff/asio
+[submodule "other/websocketpp"]
+	path = other/websocketpp
+	url = https://github.com/Logitech/logi_websocketpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,7 @@ project(logi_obs_plugin)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+add_definitions (-D_WEBSOCKETPP_CPP11_SYSTEM_ERROR_)
+add_definitions (-D_ASIO_STANDALONE_)
+
 add_subdirectory(obs_plugin)

--- a/obs_plugin/src/obs_plugin.hpp
+++ b/obs_plugin/src/obs_plugin.hpp
@@ -1,8 +1,14 @@
 #pragma once
 
 #define _WEBSOCKETPP_CPP11_RANDOM_DEVICE_
-#define ASIO_STANDALONE
-#define _WEBSOCKETPP_CPP11_TYPE_TRAITS_
+
+#ifndef ASIO_STANDALONE
+    #define ASIO_STANDALONE
+#endif
+
+#ifndef _WEBSOCKETPP_CPP11_TYPE_TRAITS_
+    #define _WEBSOCKETPP_CPP11_TYPE_TRAITS_
+#endif
 
 #pragma warning(push)
 #pragma warning(disable : 4267)


### PR DESCRIPTION
Hi there!

This is part of an epic to remove boost from our repo.
In this specific pull-request I:

1. Updated websocketpp pointer to point to our own fork
2. added two defines (WEBSOCKETPP_CPP11_SYSTEM_ERROR and ASIO_STANDALONE) so that websocketpp/asio would use STL-based implementation instead of boost.