### PR TITLE
Fix plugin display name

### DIFF
--- a/obs_plugin/src/obs_plugin.cpp
+++ b/obs_plugin/src/obs_plugin.cpp
@@ -17,7 +17,7 @@ OBS_DECLARE_MODULE()
 const char *obs_module_name()
 {
     // The full name of the module
-    return s_integration_name.c_str();
+    return s_plugin_name.c_str();
 }
 
 

--- a/obs_plugin/src/obs_plugin.cpp
+++ b/obs_plugin/src/obs_plugin.cpp
@@ -1788,6 +1788,8 @@ void logi::applets::obs_plugin::loop_function()
             fps = static_cast<double_t>(streamed_frames) - static_cast<double_t>(m_total_streamed_frames);
 
             m_total_streamed_frames = streamed_frames;
+
+            obs_output_release(obs_output);
         }
         status_payload["bitrate"] = bps;
         status_payload["framerate"] = fps;

--- a/obs_plugin/src/obs_plugin.hpp
+++ b/obs_plugin/src/obs_plugin.hpp
@@ -173,6 +173,7 @@ namespace logi
             std::condition_variable m_initialization_cv;
 
             // clang-format off
+            const std::string s_plugin_name                 = "Logitech G Plugin";
             const std::string s_integration_name            = "APPLET_OBS_NAME";
             const std::string s_integration_author          = "Logitech G";
             const std::string s_integration_description     = "A Logitech G plugin for Open Broadcaster Software, exposing additional actions to G HUB.";


### PR DESCRIPTION
This pull request updates the plugin metadata and improves resource management in the OBS plugin implementation. The most important changes include correcting the plugin name used by OBS and ensuring proper release of OBS output resources.

**Plugin metadata updates:**

* Changed the return value of `obs_module_name()` in `obs_plugin.cpp` to use `s_plugin_name` instead of `s_integration_name`, ensuring OBS displays the correct plugin name.
* Added the `s_plugin_name` constant ("Logitech G Plugin") to the `logi` namespace in `obs_plugin.hpp` for consistent naming.

**Resource management improvements:**

* Added a call to `obs_output_release(obs_output)` in the `loop_function()` to properly release OBS output resources and prevent potential memory leaks.